### PR TITLE
Safe for iOS 8 extensions

### DIFF
--- a/KSReachability/KSReachability.xcodeproj/project.pbxproj
+++ b/KSReachability/KSReachability.xcodeproj/project.pbxproj
@@ -617,6 +617,7 @@
 		D8642F151B4C1022005B5DE9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -653,6 +654,7 @@
 		D8642F161B4C1022005B5DE9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -779,6 +781,7 @@
 				D8642F161B4C1022005B5DE9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D8642F171B4C1022005B5DE9 /* Build configuration list for PBXNativeTarget "KSReachability_iOSTests" */ = {
 			isa = XCConfigurationList;
@@ -787,6 +790,7 @@
 				D8642F191B4C1022005B5DE9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
This PR marks the framework as safe for iOS 8 extensions.
I forgot to do this in the previous PR I submitted.
